### PR TITLE
Very simple deploy script

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -1,0 +1,27 @@
+"""
+Very simple deploy script that assumes a lot of existing setup
+"""
+
+from fabric.api import *
+
+code_path = '/home/ubuntu/tapmapper/tapmapper'
+
+
+def pull():
+    with cd(code_path):
+        run('git pull')
+
+
+def install():
+    with cd(code_path):
+        run('pip install -r requirements.txt')
+
+
+def serve():
+    run('supervisorctl restart all')
+
+
+def deploy():
+    pull()
+    install()
+    serve()

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,5 @@ wsgiref==0.1.2
 simplejson
 tweepy
 pandas
+
+fabric<2.0.0


### PR DESCRIPTION
Use fabric to run a git pull, install requirements, and restart server.

Deploy using `fab -H <user@host-name> deploy`.

Obviously, this took for granted the existing setup (repo cloned in a fixed path, though this could be easily set up; supervisor running).